### PR TITLE
Fix wildcard cref

### DIFF
--- a/SkiaSharpAPI/SkiaSharp/SKPaint.xml
+++ b/SkiaSharpAPI/SkiaSharp/SKPaint.xml
@@ -2380,7 +2380,7 @@ and <xref:SkiaSharp.SKPaint.PathEffect> to scale and modify the glyph paths.
 
 If this property is set true, then advances are treated as Y values rather
 than X values, and
-<xref:SkiaSharp.SKCanvas.DrawText*/> will place
+<xref:SkiaSharp.SKCanvas.DrawText%2A/> will place
 its glyphs vertically rather than horizontally.
 ]]></format>
         </remarks>

--- a/SkiaSharpAPI/SkiaSharp/SKPaint.xml
+++ b/SkiaSharpAPI/SkiaSharp/SKPaint.xml
@@ -2380,7 +2380,7 @@ and <xref:SkiaSharp.SKPaint.PathEffect> to scale and modify the glyph paths.
 
 If this property is set true, then advances are treated as Y values rather
 than X values, and
-<xref:SkiaSharp.SKCanvas.DrawText/> will place
+<xref:SkiaSharp.SKCanvas.DrawText*/> will place
 its glyphs vertically rather than horizontally.
 ]]></format>
         </remarks>


### PR DESCRIPTION
Answer is to use escaped form: <xref:T.MemberGroup%2A/> will go to MemberGroup*