### PR TITLE
Proper wildcard xref

### DIFF
--- a/SkiaSharpAPI/SkiaSharp/SKPaint.xml
+++ b/SkiaSharpAPI/SkiaSharp/SKPaint.xml
@@ -2380,7 +2380,7 @@ and <xref:SkiaSharp.SKPaint.PathEffect> to scale and modify the glyph paths.
 
 If this property is set true, then advances are treated as Y values rather
 than X values, and
-<xref:SkiaSharp.SKCanvas.DrawText(System.String,SkiaSharp.SKPoint,SkiaSharp.SKPaint)/> will place
+<xref:SkiaSharp.SKCanvas.DrawText%2A> will place
 its glyphs vertically rather than horizontally.
 ]]></format>
         </remarks>

--- a/SkiaSharpAPI/SkiaSharp/SKPaint.xml
+++ b/SkiaSharpAPI/SkiaSharp/SKPaint.xml
@@ -2380,7 +2380,7 @@ and <xref:SkiaSharp.SKPaint.PathEffect> to scale and modify the glyph paths.
 
 If this property is set true, then advances are treated as Y values rather
 than X values, and
-<xref:SkiaSharp.SKCanvas.DrawText%2A/> will place
+<xref:SkiaSharp.SKCanvas.DrawText(System.String,SkiaSharp.SKPoint,SkiaSharp.SKPaint)/> will place
 its glyphs vertically rather than horizontally.
 ]]></format>
         </remarks>


### PR DESCRIPTION
Turns out that the proper format is an unterminated element <xref:NS.T.M%2a> not <xref:NS.T.M%2a/>