### PR TITLE
Add placeholder docs for the build

### DIFF
--- a/SkiaSharpAPI/index.xml
+++ b/SkiaSharpAPI/index.xml
@@ -1701,6 +1701,9 @@
         </Attribute>
       </Attributes>
     </Assembly>
+    <Assembly Name="SkiaSharp.Views.Desktop.Common" Version="1.68.0.0" />
+    <Assembly Name="SkiaSharp.Views.Gtk3" Version="1.68.0.0" />
+    <Assembly Name="SkiaSharp.Views.WindowsForms" Version="1.68.0.0" />
   </Assemblies>
   <Remarks></Remarks>
   <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>


### PR DESCRIPTION
There are new assemblies, so we need to have the initial files so we can build.

A little bit of chicken and egg, but this is easier that writing a complex script to generate files for new assemblies. Also, the build will fail if we accidentally rename or create a new assembly.