### PR TITLE
Tried to improve SKPaint.TextSize docs

### DIFF
--- a/SkiaSharpAPI/SkiaSharp/SKPaint.xml
+++ b/SkiaSharpAPI/SkiaSharp/SKPaint.xml
@@ -2984,9 +2984,12 @@ consumes up to `length` bytes from the buffer.
         <ReturnType>System.Single</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the text size.</summary>
+        <summary>Gets or sets the text size, in pixels.</summary>
         <value></value>
-        <remarks></remarks>
+        <remarks>A glyph with size 1 EM will be rendered at this size.<br/>
+        <img src="https://docs.microsoft.com/en-us/typography/opentype/otspec182/images/img00294.gif"/><br/>
+        See also <see cref="P:SkiaSharp.SKTypeface.UnitsPerEm" />        
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="TextSkewX">


### PR DESCRIPTION
I tried to find the right words, but English is not my native language, so improvement is possible.

I'm also not sure if linking to external images is recommended, I don't know the license of the linked image (on docs.microsoft.com)
