### PR TITLE
GRContext.Create(enum) is deprecated, use GRContext.CreateGl() instead.

### DIFF
--- a/SkiaSharpAPI/SkiaSharp/SKCanvas.xml
+++ b/SkiaSharpAPI/SkiaSharp/SKCanvas.xml
@@ -113,7 +113,7 @@ current to the current thread when SkiaSharp calls are made.
 var info = new SKImageInfo(256, 256);
 
 // create the surface
-var context = GRContext.Create(GRBackend.OpenGL);
+var context = GRContext.CreateGl();
 var surface = SKSurface.Create(context, false, info);
 
 // get the canvas from the surface


### PR DESCRIPTION
As the title says, the GRContext.Create(GRBackend.OpenGL) way of creating a context is deprecated.