### PR TITLE
Fix breadcrumbs

### DIFF
--- a/SkiaSharpAPI/SkiaSharpAPI-breadcrumb/toc.yml
+++ b/SkiaSharpAPI/SkiaSharpAPI-breadcrumb/toc.yml
@@ -2,6 +2,6 @@
   tocHref: /dotnet/
   topicHref: /dotnet/index
   items:
-  - name: API browsers
+  - name: API browser
     tocHref: /dotnet/api/
     topicHref: /dotnet/api/index

--- a/SkiaSharpAPI/SkiaSharpAPI-breadcrumb/toc.yml
+++ b/SkiaSharpAPI/SkiaSharpAPI-breadcrumb/toc.yml
@@ -1,0 +1,7 @@
+- name: .NET
+  tocHref: /dotnet/
+  topicHref: /dotnet/index
+  items:
+  - name: API browsers
+    tocHref: /dotnet/api/
+    topicHref: /dotnet/api/index

--- a/SkiaSharpAPI/breadcrumb/toc.yml
+++ b/SkiaSharpAPI/breadcrumb/toc.yml
@@ -1,2 +1,0 @@
-- name: Docs
-  tocHref: /

--- a/SkiaSharpAPI/docfx.json
+++ b/SkiaSharpAPI/docfx.json
@@ -42,7 +42,7 @@
     "globalMetadata": {
       "feedback_system": "Standard",
       "apiPlatform": "dotnet",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "/dotnet/SkiaSharpAPI-breadcrumb/toc.json",
       "author": "dotnet-bot",
       "ms.author": "dotnetcontent",
       "manager": "maleib",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 