### PR TITLE
Fix automerge: only trigger on success, not every status update

### DIFF
--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -14,8 +14,10 @@ permissions:
 
 jobs:
   check-and-merge:
-    # Only run when a Learn Build status reports on the automation branch
+    # Only run when a Learn Build status succeeds on the automation branch.
+    # Ignore pending/error/failure — we only care when a status completes green.
     if: |
+      github.event.state == 'success' &&
       (github.event.context == 'OpenPublishing.Build' ||
        github.event.context == 'PoliCheck Scan') &&
       contains(github.event.branches.*.name, 'automation/write-api-docs')


### PR DESCRIPTION
Follow-up to #82. The workflow was triggering on every status state change (`pending`, `success`, `error`, `failure`), causing a stack of runs and duplicate comments per commit.

**Fix**: Add `github.event.state == 'success'` to the job condition. Now the workflow only runs when a status completes green. Combined with the script's "waiting for required statuses" check, it only comments/merges once ALL required statuses are green.