### PR TITLE
Update known-warnings baseline for PR #81

### DIFF
--- a/.github/known-warnings.csv
+++ b/.github/known-warnings.csv
@@ -5,13 +5,13 @@ SkiaSharpAPI/SkiaSharp.Views.Desktop/SKGLControl.xml,xref-not-found,Cross refere
 SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.Color'.,4
 SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.Pixbuf'.,14
 SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.Point'.,4
-SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.RGBA'.,2
-SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.Rectangle'.,4
+SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.RGBA'.,8
+SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.Rectangle'.,5
 SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Gdk.Size'.,4
-SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Point'.,1
-SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Point3D'.,1
-SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Rect'.,1
-SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Size'.,1
+SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Point'.,4
+SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Point3D'.,4
+SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Rect'.,4
+SkiaSharpAPI/SkiaSharp.Views.Gtk/GTKExtensions.xml,xref-not-found,Cross reference not found: 'Graphene.Size'.,4
 SkiaSharpAPI/SkiaSharp.Views.Gtk/SKDrawingArea.xml,xref-not-found,Cross reference not found: 'Cairo.Context'.,3
 SkiaSharpAPI/SkiaSharp.Views.Gtk/SKDrawingArea.xml,xref-not-found,Cross reference not found: 'Gtk.DrawingArea'.,1
 SkiaSharpAPI/SkiaSharp.Views.Gtk/SKWidget.xml,xref-not-found,Cross reference not found: 'Gdk.EventExpose'.,2
@@ -62,3 +62,4 @@ SkiaSharpAPI/SkiaSharp/GRVorticeD3DBackendContext.xml,xref-not-found,Cross refer
 SkiaSharpAPI/SkiaSharp/GRVorticeD3DTextureResourceInfo.xml,xref-not-found,Cross reference not found: 'Vortice.DXGI.Format'.,1
 SkiaSharpAPI/SkiaSharp/GRVorticeD3DTextureResourceInfo.xml,xref-not-found,Cross reference not found: 'Vortice.Direct3D12.ID3D12Resource'.,1
 SkiaSharpAPI/SkiaSharp/GRVorticeD3DTextureResourceInfo.xml,xref-not-found,Cross reference not found: 'Vortice.Direct3D12.ResourceStates'.,1
+SkiaSharpAPI/SkiaSharp/SKPathBuilder.xml,xref-not-found,Cross reference not found: 'SkiaSharp.SKPathBuilder.Dispose'.,1


### PR DESCRIPTION
Updates the known-warnings.csv baseline to include the 20 new xref-not-found warnings introduced by PR #81 (Fill API documentation placeholders).

**Changes** (1 file, counts only):
| Warning | Old count | New count |
|---------|-----------|-----------|
| GTKExtensions.xml: Gdk.RGBA | 2 | 8 |
| GTKExtensions.xml: Gdk.Rectangle | 4 | 5 |
| GTKExtensions.xml: Graphene.Point | 1 | 4 |
| GTKExtensions.xml: Graphene.Point3D | 1 | 4 |
| GTKExtensions.xml: Graphene.Rect | 1 | 4 |
| GTKExtensions.xml: Graphene.Size | 1 | 4 |
| SKPathBuilder.xml: SKPathBuilder.Dispose | — | 1 |

Baseline: 63 → 64 unique rows, 120 → 140 total.

Merge this **before** PR #81 so the automerge workflow can proceed.