### PR TITLE
Fix automerge: prevent duplicate comments and handle status ordering

### DIFF
--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -14,13 +14,20 @@ permissions:
 
 jobs:
   check-and-merge:
-    # Only run when a Learn Build status succeeds on the automation branch.
-    # Ignore pending/error/failure — we only care when a status completes green.
+    # Trigger when either Learn Build status succeeds on the automation branch.
+    # The script requires BOTH to be present before proceeding.
     if: |
       github.event.state == 'success' &&
       (github.event.context == 'OpenPublishing.Build' ||
        github.event.context == 'PoliCheck Scan') &&
       contains(github.event.branches.*.name, 'automation/write-api-docs')
+
+    # Only one run at a time per commit SHA. If both statuses succeed
+    # simultaneously, the second run waits then gets cancelled since
+    # the first already handled it (PR merged or comment posted).
+    concurrency:
+      group: automerge-${{ github.event.sha }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes duplicate dry-run/merge comments and handles any arrival order of statuses.

**Problems**:
1. Triggering on both `OpenPublishing.Build` and `PoliCheck Scan` caused 2 identical comments when both succeeded at roughly the same time
2. Triggering on only one status would miss the case where the other arrives last

**Fix**:
- Trigger on both statuses (handles any ordering)
- Add `concurrency: automerge-\${{ github.event.sha }}` to serialize runs per commit — if both fire simultaneously, the second waits then sees the first already handled it
- Script still requires both statuses present before proceeding; exits silently if one is missing

**Result**: exactly 1 comment per commit regardless of which status arrives first.