### PR TITLE
Enable automerge with better failure comments

### DIFF
--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -3,9 +3,8 @@ name: Auto-merge docs PR
 on:
   status:
 
-# Set to false when ready to auto-merge for real.
 env:
-  DRY_RUN: true
+  DRY_RUN: false
 
 permissions:
   contents: write


### PR DESCRIPTION
Two changes:

1. **Enable automerge** — flips `DRY_RUN` to `false`

2. **Better failure comments** — the comment now distinguishes between:
   - **Validation failures**: new warnings, check failures (shows the reason)
   - **Merge failures**: branch not up to date, SHA mismatch, etc. (shows the gh error)
   - **Both together**: if validation passes but merge fails, shows both

Example for the 'not up to date' case:
> ⚠️ **Auto-merge blocked**
>
> **Merge failed**: Pull request is not mergeable: the head branch is not up to date with the base branch.
> The PR branch needs to be updated with `main` before it can be merged.

To revert automerge: change `DRY_RUN: false` back to `DRY_RUN: true`.