### PR TITLE
Fill API documentation placeholders

### DIFF
--- a/SkiaSharpAPI/index.xml
+++ b/SkiaSharpAPI/index.xml
@@ -3129,8 +3129,6 @@
         <Docs>
           <param name="rect">The <see cref="T:SkiaSharp.SKRectI" /> to convert.</param>
           <summary>Converts an <see cref="T:SkiaSharp.SKRectI" /> to a <see cref="T:Gdk.Rectangle" />.</summary>
-          <returns>A <see cref="T:Gdk.Rectangle" /> with the same bounds.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToGdkRectangle(SkiaSharp.SKRectI)" />
       </Member>
@@ -3151,8 +3149,6 @@
         <Docs>
           <param name="color">The <see cref="T:SkiaSharp.SKColor" /> to convert.</param>
           <summary>Converts an <see cref="T:SkiaSharp.SKColor" /> to a <see cref="T:Gdk.RGBA" />.</summary>
-          <returns>A <see cref="T:Gdk.RGBA" /> with equivalent color values.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToGdkRGBA(SkiaSharp.SKColor)" />
       </Member>
@@ -3173,8 +3169,6 @@
         <Docs>
           <param name="color">The <see cref="T:SkiaSharp.SKColorF" /> to convert.</param>
           <summary>Converts an <see cref="T:SkiaSharp.SKColorF" /> to a <see cref="T:Gdk.RGBA" />.</summary>
-          <returns>A <see cref="T:Gdk.RGBA" /> with equivalent color values.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToGdkRGBA(SkiaSharp.SKColorF)" />
       </Member>
@@ -3195,8 +3189,6 @@
         <Docs>
           <param name="point">The <see cref="T:SkiaSharp.SKPoint" /> to convert.</param>
           <summary>Converts an <see cref="T:SkiaSharp.SKPoint" /> to a <see cref="T:Graphene.Point" />.</summary>
-          <returns>A <see cref="T:Graphene.Point" /> with the same coordinates.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToGraphenePoint(SkiaSharp.SKPoint)" />
       </Member>
@@ -3217,8 +3209,6 @@
         <Docs>
           <param name="point">The <see cref="T:SkiaSharp.SKPoint3" /> to convert.</param>
           <summary>Converts an <see cref="T:SkiaSharp.SKPoint3" /> to a <see cref="T:Graphene.Point3D" />.</summary>
-          <returns>A <see cref="T:Graphene.Point3D" /> with the same coordinates.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToGraphenePoint3D(SkiaSharp.SKPoint3)" />
       </Member>
@@ -3239,8 +3229,6 @@
         <Docs>
           <param name="rect">The <see cref="T:SkiaSharp.SKRect" /> to convert.</param>
           <summary>Converts an <see cref="T:SkiaSharp.SKRect" /> to a <see cref="T:Graphene.Rect" />.</summary>
-          <returns>A <see cref="T:Graphene.Rect" /> with the same bounds.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToGrapheneRect(SkiaSharp.SKRect)" />
       </Member>
@@ -3261,8 +3249,6 @@
         <Docs>
           <param name="size">The <see cref="T:SkiaSharp.SKSize" /> to convert.</param>
           <summary>Converts an <see cref="T:SkiaSharp.SKSize" /> to a <see cref="T:Graphene.Size" />.</summary>
-          <returns>A <see cref="T:Graphene.Size" /> with the same dimensions.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToGrapheneSize(SkiaSharp.SKSize)" />
       </Member>
@@ -3483,8 +3469,6 @@
         <Docs>
           <param name="color">The <see cref="T:Gdk.RGBA" /> to convert.</param>
           <summary>Converts a <see cref="T:Gdk.RGBA" /> to an <see cref="T:SkiaSharp.SKColor" />.</summary>
-          <returns>An <see cref="T:SkiaSharp.SKColor" /> with equivalent color values.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToSKColor(Gdk.RGBA)" />
       </Member>
@@ -3505,8 +3489,6 @@
         <Docs>
           <param name="color">The <see cref="T:Gdk.RGBA" /> to convert.</param>
           <summary>Converts a <see cref="T:Gdk.RGBA" /> to an <see cref="T:SkiaSharp.SKColorF" />.</summary>
-          <returns>An <see cref="T:SkiaSharp.SKColorF" /> with equivalent color values.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToSKColorF(Gdk.RGBA)" />
       </Member>
@@ -3573,8 +3555,6 @@
         <Docs>
           <param name="point">The <see cref="T:Graphene.Point" /> to convert.</param>
           <summary>Converts a <see cref="T:Graphene.Point" /> to an <see cref="T:SkiaSharp.SKPoint" />.</summary>
-          <returns>An <see cref="T:SkiaSharp.SKPoint" /> with the same coordinates.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToSKPoint(Graphene.Point)" />
       </Member>
@@ -3595,8 +3575,6 @@
         <Docs>
           <param name="point">The <see cref="T:Graphene.Point3D" /> to convert.</param>
           <summary>Converts a <see cref="T:Graphene.Point3D" /> to an <see cref="T:SkiaSharp.SKPoint3" />.</summary>
-          <returns>An <see cref="T:SkiaSharp.SKPoint3" /> with the same coordinates.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToSKPoint3(Graphene.Point3D)" />
       </Member>
@@ -3639,8 +3617,6 @@
         <Docs>
           <param name="rect">The <see cref="T:Graphene.Rect" /> to convert.</param>
           <summary>Converts a <see cref="T:Graphene.Rect" /> to an <see cref="T:SkiaSharp.SKRect" />.</summary>
-          <returns>An <see cref="T:SkiaSharp.SKRect" /> with the same bounds.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToSKRect(Graphene.Rect)" />
       </Member>
@@ -3683,8 +3659,6 @@
         <Docs>
           <param name="size">The <see cref="T:Graphene.Size" /> to convert.</param>
           <summary>Converts a <see cref="T:Graphene.Size" /> to an <see cref="T:SkiaSharp.SKSize" />.</summary>
-          <returns>An <see cref="T:SkiaSharp.SKSize" /> with the same dimensions.</returns>
-          <remarks></remarks>
         </Docs>
         <Link Type="SkiaSharp.Views.Gtk.GTKExtensions" Member="M:SkiaSharp.Views.Gtk.GTKExtensions.ToSKSize(Graphene.Size)" />
       </Member>


### PR DESCRIPTION
Automated AI-generated documentation for XML API docs with 'To be added.' placeholders.

Created by [auto-api-docs-writer](https://github.com/mono/SkiaSharp/actions/workflows/auto-api-docs-writer.lock.yml).