### PR TITLE
Add output/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tree
 *.zip
 tmp
+output/


### PR DESCRIPTION
Prevents intermediate work files (e.g. `output/docs-work/*.json`) from being accidentally committed by automation agents.

This was discovered after PR #113 inadvertently included the `output/docs-work/` directory because the agent ran `git add output/docs-work/` before committing, and nothing in `.gitignore` excluded it.