### PR TITLE
Move extraction to gen job and add artifact audit trail

### DIFF
--- a/.github/workflows/auto-api-docs-writer.lock.yml
+++ b/.github/workflows/auto-api-docs-writer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b01557de21e89fbab66a67c6c4bf090641da579e4df264707ddb91f151015f10","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ee0b83f9557935df28356851297da8f9275b8282c2b09d4c34fea266d3602e16","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"0057852bfaa89a56745cba8c7296529d2fc39830","version":"v4"},{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9","version":"v4"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -219,23 +219,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f13c438bc17fdea5_EOF'
+          cat << 'GH_AW_PROMPT_e5660c6c744a78d6_EOF'
           <system>
-          GH_AW_PROMPT_f13c438bc17fdea5_EOF
+          GH_AW_PROMPT_e5660c6c744a78d6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f13c438bc17fdea5_EOF'
+          cat << 'GH_AW_PROMPT_e5660c6c744a78d6_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_f13c438bc17fdea5_EOF
+          GH_AW_PROMPT_e5660c6c744a78d6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_f13c438bc17fdea5_EOF'
+          cat << 'GH_AW_PROMPT_e5660c6c744a78d6_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_f13c438bc17fdea5_EOF
+          GH_AW_PROMPT_e5660c6c744a78d6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_f13c438bc17fdea5_EOF'
+          cat << 'GH_AW_PROMPT_e5660c6c744a78d6_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -267,12 +267,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_f13c438bc17fdea5_EOF
+          GH_AW_PROMPT_e5660c6c744a78d6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f13c438bc17fdea5_EOF'
+          cat << 'GH_AW_PROMPT_e5660c6c744a78d6_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-api-docs-writer.md}}
-          GH_AW_PROMPT_f13c438bc17fdea5_EOF
+          GH_AW_PROMPT_e5660c6c744a78d6_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -459,14 +459,19 @@ jobs:
         with:
           name: docs-regenerated
           path: SkiaSharpAPI/
+      - name: Download pre-extracted JSON
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: docs-extracted
+          path: output/docs-work/
       - env:
           SKIASHARP_BRANCH: ${{ inputs.skiasharp_branch || 'main' }}
         name: Clone SkiaSharp (shallow, with submodules)
         run: "git clone --depth 1 --branch \"$SKIASHARP_BRANCH\" \\\n  --recurse-submodules --shallow-submodules \\\n  https://github.com/mono/SkiaSharp.git skiasharp\nmkdir -p skiasharp/docs\nln -sfn \"$(pwd)/SkiaSharpAPI\" skiasharp/docs/SkiaSharpAPI\ncd skiasharp && dotnet tool restore\n"
-      - name: Extract placeholders and manifest
+      - name: Save original JSON to agent artifact cache
         run: |-
-          mkdir -p output/docs-work
-          pwsh skiasharp/.agents/skills/api-docs/scripts/docs-tool.ps1 extract SkiaSharpAPI/ -Output output/docs-work/
+          mkdir -p /tmp/gh-aw/agent/docs-work-original
+          cp -r output/docs-work/* /tmp/gh-aw/agent/docs-work-original/
 
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
@@ -475,9 +480,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_cb3252e91cdaec4f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c2d4d133de8c2ed7_EOF'
           {"create_pull_request":{"base_branch":"main","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_cb3252e91cdaec4f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c2d4d133de8c2ed7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -683,7 +688,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f43305c2a999d47d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_25debe57faeea757_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -731,7 +736,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f43305c2a999d47d_EOF
+          GH_AW_MCP_CONFIG_25debe57faeea757_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -924,6 +929,10 @@ jobs:
           if [ ! -f /tmp/gh-aw/agent_output.json ]; then
             echo '{"items":[]}' > /tmp/gh-aw/agent_output.json
           fi
+      - name: Save final JSON to agent artifact cache
+        run: |
+          mkdir -p /tmp/gh-aw/agent/docs-work-final
+          cp -r output/docs-work/* /tmp/gh-aw/agent/docs-work-final/
       - name: Format docs
         run: cd skiasharp && dotnet cake --target=docs-format-docs
 
@@ -1388,12 +1397,23 @@ jobs:
         run: dotnet cake --target=docs-download-output
       - name: Regenerate API docs
         run: dotnet cake --target=update-docs
+      - name: Extract placeholders and manifest
+        run: |
+          New-Item -ItemType Directory -Path output/docs-work -Force | Out-Null
+          & .agents/skills/api-docs/scripts/docs-tool.ps1 extract docs/SkiaSharpAPI/ -Output output/docs-work/
+        shell: pwsh
       - name: Upload regenerated docs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-regenerated
           path: docs/SkiaSharpAPI/
           retention-days: 1
+      - name: Upload extracted JSON (immutable baseline)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: docs-extracted
+          path: output/docs-work/
+          retention-days: 7
 
   safe_outputs:
     needs:

--- a/.github/workflows/auto-api-docs-writer.md
+++ b/.github/workflows/auto-api-docs-writer.md
@@ -229,8 +229,11 @@ If there are no documentation changes after merging, call the `noop` tool instea
 - **Do NOT edit XML files directly** — edit only the JSON files in `output/docs-work/`.
 - **Phase 6 MUST run.** If you skip the merge, no PR is created and the entire run is wasted.
 - **Do NOT run `docs-format-docs`** — formatting runs automatically as a post-step.
-- **Budget awareness:** After the writer completes and reviewers report, fix CRITICAL issues and proceed to merge+PR immediately. Do not re-run reviewers unless absolutely necessary.
-- **NEVER end a turn without a tool call while waiting for agents.** When you launch a background agent and need its result, you MUST call `read_agent` with `wait: true` in the SAME turn. Do NOT just say "waiting" in text and end your turn — the session will terminate. The pattern is: launch agent → immediately call `read_agent(agent_id, wait=true)` → process result → continue.
+- **Budget awareness:** After the writer completes and reviewers report, fix CRITICAL issues and proceed to merge+PR immediately. Do not re-run reviewers unless absolutely necessary. **If you're past 10 minutes and haven't merged yet, skip Phase 5 (review) entirely and go straight to Phase 6 (merge) + PR. A PR without review is better than no PR.**
+- **NEVER end a turn without a tool call while waiting for agents.** When you launch a background agent, you MUST call `read_agent` with `wait: true` in the SAME response. Do NOT output text saying "waiting" and end your turn — the session WILL terminate and all work is lost.
+  - **Single agent:** `task(background)` + `read_agent(id, wait=true)` in the same response.
+  - **Multiple agents:** Launch all agents, then call `read_agent` for THE FIRST ONE with `wait: true`. When it returns, call `read_agent` for the next, and so on. You MUST have an active `read_agent` call at all times until all agents complete.
+  - **FORBIDDEN pattern:** Launching agents → saying "Waiting for them to complete" → ending turn. This KILLS the session.
 - **COMPLETION GATE:** Your session is NOT complete until you have called `create_pull_request` or `noop`. If you reach a point where you think you're done but haven't called either, something went wrong — retrace your steps and complete the remaining phases.
 
 ## Path differences from SKILL.md

--- a/.github/workflows/auto-api-docs-writer.md
+++ b/.github/workflows/auto-api-docs-writer.md
@@ -81,12 +81,23 @@ jobs:
         run: dotnet cake --target=docs-download-output
       - name: Regenerate API docs
         run: dotnet cake --target=update-docs
+      - name: Extract placeholders and manifest
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path output/docs-work -Force | Out-Null
+          & .agents/skills/api-docs/scripts/docs-tool.ps1 extract docs/SkiaSharpAPI/ -Output output/docs-work/
       - name: Upload regenerated docs
         uses: actions/upload-artifact@v4
         with:
           name: docs-regenerated
           path: docs/SkiaSharpAPI/
           retention-days: 1
+      - name: Upload extracted JSON (immutable baseline)
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-extracted
+          path: output/docs-work/
+          retention-days: 7
 
 # -- Checkout ----------------------------------------------------------
 # Primary: this docs repo only. SkiaSharp is cloned in pre-agent-steps.
@@ -133,6 +144,12 @@ pre-agent-steps:
       name: docs-regenerated
       path: SkiaSharpAPI/
 
+  - name: Download pre-extracted JSON
+    uses: actions/download-artifact@v4
+    with:
+      name: docs-extracted
+      path: output/docs-work/
+
   - name: Clone SkiaSharp (shallow, with submodules)
     env:
       SKIASHARP_BRANCH: ${{ inputs.skiasharp_branch || 'main' }}
@@ -144,15 +161,20 @@ pre-agent-steps:
       ln -sfn "$(pwd)/SkiaSharpAPI" skiasharp/docs/SkiaSharpAPI
       cd skiasharp && dotnet tool restore
 
-  - name: Extract placeholders and manifest
+  - name: Save original JSON to agent artifact cache
     run: |
-      mkdir -p output/docs-work
-      pwsh skiasharp/.agents/skills/api-docs/scripts/docs-tool.ps1 extract SkiaSharpAPI/ -Output output/docs-work/
+      mkdir -p /tmp/gh-aw/agent/docs-work-original
+      cp -r output/docs-work/* /tmp/gh-aw/agent/docs-work-original/
 
 # -- Post-agent steps (host) ------------------------------------------
 # Format docs AFTER the agent merges JSON→XML. Runs on host outside the
 # sandbox so it has full access to the SkiaSharp cake scripts.
 post-steps:
+  - name: Save final JSON to agent artifact cache
+    run: |
+      mkdir -p /tmp/gh-aw/agent/docs-work-final
+      cp -r output/docs-work/* /tmp/gh-aw/agent/docs-work-final/
+
   - name: Format docs
     run: cd skiasharp && dotnet cake --target=docs-format-docs
 ---

--- a/.github/workflows/auto-api-docs-writer.md
+++ b/.github/workflows/auto-api-docs-writer.md
@@ -230,6 +230,8 @@ If there are no documentation changes after merging, call the `noop` tool instea
 - **Phase 6 MUST run.** If you skip the merge, no PR is created and the entire run is wasted.
 - **Do NOT run `docs-format-docs`** — formatting runs automatically as a post-step.
 - **Budget awareness:** After the writer completes and reviewers report, fix CRITICAL issues and proceed to merge+PR immediately. Do not re-run reviewers unless absolutely necessary.
+- **NEVER end a turn without a tool call while waiting for agents.** When you launch a background agent and need its result, you MUST call `read_agent` with `wait: true` in the SAME turn. Do NOT just say "waiting" in text and end your turn — the session will terminate. The pattern is: launch agent → immediately call `read_agent(agent_id, wait=true)` → process result → continue.
+- **COMPLETION GATE:** Your session is NOT complete until you have called `create_pull_request` or `noop`. If you reach a point where you think you're done but haven't called either, something went wrong — retrace your steps and complete the remaining phases.
 
 ## Path differences from SKILL.md
 


### PR DESCRIPTION
## Summary

Moves placeholder extraction from the agent runtime into the mechanical `regenerate-stubs` CI job, adds artifact audit trail, and strengthens the agent prompt to prevent session termination failures.

**Companion PR:** [mono/SkiaSharp#4030](https://github.com/mono/SkiaSharp/pull/4030) (merge guard, anchored regex, SKILL.md fixes)

## Context

Reviewed [PR #115](https://github.com/mono/SkiaSharp-API-docs/pull/115) and found the automated docs pipeline had systemic issues:
- False-positive regex extracting already-documented members
- No merge guard allowing agent to invent fields
- No audit trail to compare before/after
- Agent session termination when waiting for background sub-agents

## Workflow Changes

### Extraction moved to `regenerate-stubs` job (mechanical)
- Extraction now runs in the Windows gen job alongside mdoc, not in the agent container
- Produces `docs-extracted` artifact (7-day retention) as an immutable baseline
- Agent downloads pre-extracted JSON — no extraction at runtime

### Artifact audit trail
- **Pre-agent step**: copies original JSON to `/tmp/gh-aw/agent/docs-work-original/`
- **Post-step**: copies final JSON to `/tmp/gh-aw/agent/docs-work-final/`
- Both are uploaded as part of the agent artifact for diffing

### Agent prompt hardening (session termination fix)
- **Problem**: In runs 2 and 5, the orchestrator launched background agents, said "waiting" in text, ended its turn with NO active tool call, and the Copilot CLI terminated the session. All work was lost.
- **Fix**: Explicit rules requiring `read_agent(wait=true)` in the same response as agent launch, with multi-agent sequential pattern documented. FORBIDDEN pattern called out. Budget fallback: skip Phase 5 if past 10 minutes.
- **COMPLETION GATE**: Session cannot end without `create_pull_request` or `noop` call.

## Validation Runs

| Run | Duration | Result | PR | Notes |
|-----|----------|--------|----|-------|
| [Run 1](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26201758399) | 25m | ✅ | [#117](https://github.com/mono/SkiaSharp-API-docs/pull/117) | First validation |
| [Run 2](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26203306276) | 10m | ❌ | — | Session terminated (writer wait) |
| [Run 3](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26205171285) | 25m | ✅ | [#118](https://github.com/mono/SkiaSharp-API-docs/pull/118) | Second validation |
| [Run 4](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26240721733) | 23m | ✅ | [#119](https://github.com/mono/SkiaSharp-API-docs/pull/119) | Single-agent fix in place |
| [Run 5](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26242532530) | 13m | ❌ | — | Session terminated (reviewer wait) |
| [Run 6](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26243841508) | 16m | ✅ | [#120](https://github.com/mono/SkiaSharp-API-docs/pull/120) | **Multi-agent fix applied** |
| [Run 7](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26245160027) | 23m | ✅ | [#121](https://github.com/mono/SkiaSharp-API-docs/pull/121) | Multi-agent fix ✅ |
| [Run 8](https://github.com/mono/SkiaSharp-API-docs/actions/runs/26246814920) | 20m | ✅ | [#122](https://github.com/mono/SkiaSharp-API-docs/pull/122) | Multi-agent fix ✅ |

**Results:** 3/3 post-fix runs succeeded (100%). Pre-fix had 2/5 failures (40% failure rate).