### PR TITLE
Skip agent job when there are no API doc placeholders

### DIFF
--- a/.github/workflows/auto-api-docs-writer.lock.yml
+++ b/.github/workflows/auto-api-docs-writer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d74377dfeb3220592de0b044555f57b6f2758da8ebffb69185355672984d84df","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fa5cb8f4785da6158a48c2a4662ccc3acf1bdddb46eb35f6ad83a28dfc2eb37c","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"0057852bfaa89a56745cba8c7296529d2fc39830","version":"v4"},{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9","version":"v4"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -201,23 +201,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a9cbb40a4aa95c57_EOF'
+          cat << 'GH_AW_PROMPT_5707583c15255345_EOF'
           <system>
-          GH_AW_PROMPT_a9cbb40a4aa95c57_EOF
+          GH_AW_PROMPT_5707583c15255345_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a9cbb40a4aa95c57_EOF'
+          cat << 'GH_AW_PROMPT_5707583c15255345_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_a9cbb40a4aa95c57_EOF
+          GH_AW_PROMPT_5707583c15255345_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_a9cbb40a4aa95c57_EOF'
+          cat << 'GH_AW_PROMPT_5707583c15255345_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_a9cbb40a4aa95c57_EOF
+          GH_AW_PROMPT_5707583c15255345_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a9cbb40a4aa95c57_EOF'
+          cat << 'GH_AW_PROMPT_5707583c15255345_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -249,12 +249,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_a9cbb40a4aa95c57_EOF
+          GH_AW_PROMPT_5707583c15255345_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a9cbb40a4aa95c57_EOF'
+          cat << 'GH_AW_PROMPT_5707583c15255345_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-api-docs-writer.md}}
-          GH_AW_PROMPT_a9cbb40a4aa95c57_EOF
+          GH_AW_PROMPT_5707583c15255345_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -332,6 +332,7 @@ jobs:
     needs:
       - activation
       - regenerate-stubs
+    if: needs.regenerate-stubs.outputs.has_placeholders == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -462,9 +463,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0f9919760fb1f6c1_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_aa1706ede41622fd_EOF'
           {"create_pull_request":{"base_branch":"main","draft":false,"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0f9919760fb1f6c1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_aa1706ede41622fd_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -670,7 +671,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_dc4a8f8b337ab7b3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ba924dda319ce3f9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -718,7 +719,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dc4a8f8b337ab7b3_EOF
+          GH_AW_MCP_CONFIG_ba924dda319ce3f9_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1314,6 +1315,8 @@ jobs:
   regenerate-stubs:
     needs: activation
     runs-on: ubuntu-latest
+    outputs:
+      has_placeholders: ${{ steps.extract.outputs.has_placeholders }}
     steps:
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
@@ -1363,9 +1366,19 @@ jobs:
       - name: Regenerate API docs
         run: bash scripts/infra/docs/generate-api-docs.sh
       - name: Extract placeholders and manifest
+        id: extract
         run: |
           New-Item -ItemType Directory -Path output/docs-work -Force | Out-Null
           & .agents/skills/api-docs/scripts/docs-tool.ps1 extract docs/SkiaSharpAPI/ -Output output/docs-work/
+          # Signal downstream whether there is any work for the agent. The extract
+          # writes one JSON per type that still has 'To be added.' placeholders (plus
+          # manifest.json); zero such files means every API is already documented and
+          # the agent job can be skipped entirely.
+          $work = @(Get-ChildItem -Path output/docs-work -Filter *.json |
+            Where-Object { $_.Name -ne 'manifest.json' })
+          $hasPlaceholders = if ($work.Count -gt 0) { 'true' } else { 'false' }
+          Write-Host "has_placeholders=$hasPlaceholders ($($work.Count) file(s) with placeholders)"
+          "has_placeholders=$hasPlaceholders" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
         shell: pwsh
       - name: Upload regenerated docs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/auto-api-docs-writer.md
+++ b/.github/workflows/auto-api-docs-writer.md
@@ -32,6 +32,10 @@ on:
 jobs:
   regenerate-stubs:
     runs-on: ubuntu-latest
+    outputs:
+      # 'true' only when the extract produced at least one type JSON with
+      # 'To be added.' placeholders. Used to gate (skip) the agent job.
+      has_placeholders: ${{ steps.extract.outputs.has_placeholders }}
     steps:
       - name: Checkout SkiaSharp
         uses: actions/checkout@v4
@@ -72,10 +76,20 @@ jobs:
       - name: Regenerate API docs
         run: bash scripts/infra/docs/generate-api-docs.sh
       - name: Extract placeholders and manifest
+        id: extract
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path output/docs-work -Force | Out-Null
           & .agents/skills/api-docs/scripts/docs-tool.ps1 extract docs/SkiaSharpAPI/ -Output output/docs-work/
+          # Signal downstream whether there is any work for the agent. The extract
+          # writes one JSON per type that still has 'To be added.' placeholders (plus
+          # manifest.json); zero such files means every API is already documented and
+          # the agent job can be skipped entirely.
+          $work = @(Get-ChildItem -Path output/docs-work -Filter *.json |
+            Where-Object { $_.Name -ne 'manifest.json' })
+          $hasPlaceholders = if ($work.Count -gt 0) { 'true' } else { 'false' }
+          Write-Host "has_placeholders=$hasPlaceholders ($($work.Count) file(s) with placeholders)"
+          "has_placeholders=$hasPlaceholders" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
       - name: Upload regenerated docs
         uses: actions/upload-artifact@v4
         with:
@@ -88,6 +102,15 @@ jobs:
           name: docs-extracted
           path: output/docs-work/
           retention-days: 7
+
+# -- Agent gating ------------------------------------------------------
+# Skip the agentic writer entirely when stub regeneration found no
+# 'To be added.' placeholders. Without this gate the agent job still spins
+# up (runner + Copilot CLI + sandbox containers) only to discover there is
+# nothing to document and no-op. This top-level `if:` is applied to the
+# agent job, which already depends on (needs) the regenerate-stubs job, so
+# its `has_placeholders` output is available here.
+if: ${{ needs.regenerate-stubs.outputs.has_placeholders == 'true' }}
 
 # -- Checkout ----------------------------------------------------------
 # Primary: this docs repo only. SkiaSharp is cloned in pre-agent-steps.


### PR DESCRIPTION
## Problem

The `auto-api-docs-writer` pipeline runs the agentic writer (`agent`) job **unconditionally** after `regenerate-stubs` (`agent` only declares `needs: [activation, regenerate-stubs]`, with no "is there any work?" guard).

On a day when every API is already documented — zero `To be added.` placeholders — the `regenerate-stubs` extract produces no per-type JSON, so the agent has nothing to do. Yet the job still:

- spins up an `ubuntu-latest` runner,
- installs the Copilot CLI and AWF binary,
- pulls the sandbox container images (firewall/api-proxy/squid/mcp/github-mcp-server),

…only to read an empty manifest, discover there's nothing to document, and `noop`. That's wasted runner-minutes and image pulls every quiet day.

## Fix

Gate the `agent` job so it is **skipped entirely** when there are no placeholders:

1. `regenerate-stubs` now exposes a job output `has_placeholders`, computed in the *Extract placeholders and manifest* step. It is `'true'` only when the extract wrote at least one per-type JSON (i.e. at least one type still has a `To be added.` placeholder), `'false'` otherwise.
2. A top-level `if:` in the workflow frontmatter — which gh-aw applies to the `agent` job — reads that output: `needs.regenerate-stubs.outputs.has_placeholders == 'true'`. The `agent` job already `needs` `regenerate-stubs`, so the output is in scope.

When the agent is skipped, the framework jobs already short-circuit on `needs.agent.result != 'skipped'`:

- `detection`: `always() && needs.agent.result != 'skipped' && (...)` → skipped
- `conclusion`: `always() && (needs.agent.result != 'skipped' || lockdown/stale failures)` → skipped
- `safe_outputs`: `(!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'` → skipped (no PR)

So a no-placeholder day ends as a clean, cheap run with no PR — instead of booting the full agentic sandbox to no-op. Skipping the agent is a first-class supported state in gh-aw (the `max-daily-ai-credits` guardrail uses the same mechanism).

## Files

- `.github/workflows/auto-api-docs-writer.md` — source: `regenerate-stubs` job output + extract-step logic + top-level `if:` gate.
- `.github/workflows/auto-api-docs-writer.lock.yml` — regenerated with `gh aw compile` (v0.71.5, matching the existing generator version). The only functional diffs are the agent `if:`, the `regenerate-stubs` `outputs:`, and the extract step; the rest are deterministic prompt/EOF hash regenerations.

## Verification

- `gh aw compile` succeeds (0 errors; the lone warning about the fixed daily schedule is pre-existing).
- Verified the generated `agent` job carries `if: needs.regenerate-stubs.outputs.has_placeholders == 'true'`.
- Ran the new PowerShell gating snippet locally (PowerShell 7.4.6) against simulated extract outputs:
  - only `manifest.json` present → `has_placeholders=false` (agent would skip)
  - one per-type JSON present → `has_placeholders=true` (agent would run)

## Related

Complements mono/SkiaSharp#4238, which makes `docs-tool.ps1` always write `manifest.json` (even `[]`) so the `docs-extracted` artifact is never empty. That PR hardens the artifact/baseline; this PR avoids booting the agent at all when there's nothing to document.
