### PR TITLE
Fix obsolete cross-references in API docs (DrawInSurface, ISKRenderer, SKPaint text props)

### DIFF
--- a/SkiaSharpAPI/SkiaSharp.Views.Android/SKGLSurfaceView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.Android/SKGLSurfaceView.xml
@@ -121,12 +121,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then
-> renderers are used instead of events. See
-> <xref:SkiaSharp.Views.Android.SKGLSurfaceView.ISKRenderer> and
-> <xref:SkiaSharp.Views.Android.SKGLSurfaceView.SetRenderer(SkiaSharp.Views.Android.SKGLSurfaceView.ISKRenderer)>.
-
 ## Examples
 
 ```csharp
@@ -173,12 +167,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.Android.SKGLSurfaceView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then
-> renderers are used instead of events. See
-> <xref:SkiaSharp.Views.Android.SKGLSurfaceView.ISKRenderer> and
-> <xref:SkiaSharp.Views.Android.SKGLSurfaceView.SetRenderer(SkiaSharp.Views.Android.SKGLSurfaceView.ISKRenderer)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.Android/SKGLTextureView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.Android/SKGLTextureView.xml
@@ -121,12 +121,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then
-> renderers are used instead of events. See
-> <xref:SkiaSharp.Views.Android.SKGLTextureView.ISKRenderer> and
-> <xref:SkiaSharp.Views.Android.SKGLTextureView.SetRenderer(SkiaSharp.Views.Android.SKGLTextureView.ISKRenderer)>.
-
 ## Examples
 
 ```csharp
@@ -173,12 +167,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.Android.SKGLTextureView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then
-> renderers are used instead of events. See
-> <xref:SkiaSharp.Views.Android.SKGLTextureView.ISKRenderer> and
-> <xref:SkiaSharp.Views.Android.SKGLTextureView.SetRenderer(SkiaSharp.Views.Android.SKGLTextureView.ISKRenderer)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.Mac/SKCanvasLayer.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.Mac/SKCanvasLayer.xml
@@ -142,12 +142,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKCanvasLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKCanvasLayer.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -194,12 +188,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.Mac.SKCanvasLayer.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKCanvasLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKCanvasLayer.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.Mac/SKCanvasView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.Mac/SKCanvasView.xml
@@ -204,12 +204,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKCanvasView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKCanvasView.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -256,12 +250,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.Mac.SKCanvasView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKCanvasView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKCanvasView.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.Mac/SKGLLayer.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.Mac/SKGLLayer.xml
@@ -125,12 +125,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKGLLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKGLLayer.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintGLSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -177,12 +171,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.Mac.SKGLLayer.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKGLLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKGLLayer.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintGLSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.Mac/SKGLView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.Mac/SKGLView.xml
@@ -181,12 +181,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKGLView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKGLView.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintGLSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -233,12 +227,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.Mac.SKGLView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.Mac.SKGLView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.Mac.SKGLView.OnPaintSurface(SkiaSharp.Views.Mac.SKPaintGLSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.iOS/SKCanvasLayer.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.iOS/SKCanvasLayer.xml
@@ -142,12 +142,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKCanvasLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKCanvasLayer.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -194,12 +188,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.iOS.SKCanvasLayer.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKCanvasLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKCanvasLayer.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.iOS/SKCanvasView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.iOS/SKCanvasView.xml
@@ -229,12 +229,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKCanvasView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKCanvasView.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -281,12 +275,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.iOS.SKCanvasView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKCanvasView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKCanvasView.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.iOS/SKGLLayer.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.iOS/SKGLLayer.xml
@@ -158,12 +158,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKGLLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKGLLayer.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintGLSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -210,12 +204,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.iOS.SKGLLayer.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKGLLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKGLLayer.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintGLSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.iOS/SKGLView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.iOS/SKGLView.xml
@@ -232,12 +232,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKGLView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKGLView.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintGLSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -284,12 +278,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.iOS.SKGLView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.iOS.SKGLView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.iOS.SKGLView.OnPaintSurface(SkiaSharp.Views.iOS.SKPaintGLSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKCanvasLayer.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKCanvasLayer.xml
@@ -142,12 +142,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKCanvasLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKCanvasLayer.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -194,12 +188,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.tvOS.SKCanvasLayer.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKCanvasLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKCanvasLayer.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKCanvasView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKCanvasView.xml
@@ -229,12 +229,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKCanvasView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKCanvasView.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -281,12 +275,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.tvOS.SKCanvasView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKCanvasView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.SKImageInfo)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKCanvasView.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKGLLayer.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKGLLayer.xml
@@ -158,12 +158,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKGLLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKGLLayer.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintGLSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -210,12 +204,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.tvOS.SKGLLayer.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKGLLayer.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKGLLayer.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintGLSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKGLView.xml
+++ b/SkiaSharpAPI/SkiaSharp.Views.tvOS/SKGLView.xml
@@ -232,12 +232,6 @@ event.
 > If this method is overridden, then the base must be called, otherwise the
 > event will not be fired.
 
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKGLView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKGLView.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintGLSurfaceEventArgs)>.
-
 ## Examples
 
 ```csharp
@@ -284,12 +278,6 @@ There are two ways to draw on this surface: by overriding the
 method, or by attaching a handler to the
 <xref:SkiaSharp.Views.tvOS.SKGLView.PaintSurface>
 event.
-
-> [!NOTE]
-> If a version of SkiaSharp prior to version v1.68.x is being used, then the
-> <xref:SkiaSharp.Views.tvOS.SKGLView.DrawInSurface(SkiaSharp.SKSurface,SkiaSharp.GRBackendRenderTargetDesc)>
-> method should be overridden instead of
-> <xref:SkiaSharp.Views.tvOS.SKGLView.OnPaintSurface(SkiaSharp.Views.tvOS.SKPaintGLSurfaceEventArgs)>.
 
 ## Examples
 

--- a/SkiaSharpAPI/SkiaSharp/SKTypeface.xml
+++ b/SkiaSharpAPI/SkiaSharp/SKTypeface.xml
@@ -16,11 +16,11 @@
       <format type="text/markdown"><![CDATA[
 ## Remarks
 
-This is used in the paint, along with optionally algorithmic settings like
-<xref:SkiaSharp.SKPaint.TextSize?displayProperty=nameWithType>,
-<xref:SkiaSharp.SKPaint.TextSkewX?displayProperty=nameWithType>,
-<xref:SkiaSharp.SKPaint.TextScaleX?displayProperty=nameWithType>, and 
-<xref:SkiaSharp.SKPaint.FakeBoldText?displayProperty=nameWithType>
+This is used in the font, along with optionally algorithmic settings like
+<xref:SkiaSharp.SKFont.Size?displayProperty=nameWithType>,
+<xref:SkiaSharp.SKFont.SkewX?displayProperty=nameWithType>,
+<xref:SkiaSharp.SKFont.ScaleX?displayProperty=nameWithType>, and 
+<xref:SkiaSharp.SKFont.Embolden?displayProperty=nameWithType>
 to specify how text appears when drawn (and measured).
 
 Typeface objects are immutable, and so they can be shared between threads.


### PR DESCRIPTION
## Summary

Fixes **36 `xref-not-found` build warnings** that were blocking the Go Live publish (#171). These are dangling `<xref:>` links in 2019-era hand-written conceptual prose (`<remarks>`/`[!NOTE]` blocks) that point at SkiaSharp API members which were later removed or relocated. The link targets disappeared when commit `1dd7575` ("Regenerate frameworks docs: latest-only monikers (#141)") dropped the old member/type pages, but the prose linking to them was never updated.

These are ECMA/mdoc XML docs — the `<remarks>`/`<summary>` prose is hand-authored and preserved across regeneration, so editing the prose is the correct, safe fix. No generated `<Member>` signatures or `<Parameters>` were touched.

## Changes per group

### Group 1 — Obsolete Apple `DrawInSurface` notes (24 instances)
Removed the obsolete `> [!NOTE]` blocks that told pre-v1.68 users to override `DrawInSurface` instead of `OnPaintSurface`. `DrawInSurface` was removed after v1.68.x (replaced by `OnPaintSurface`), so the note is ~8 years obsolete.
- `SkiaSharp.Views.Mac/{SKCanvasLayer,SKCanvasView,SKGLLayer,SKGLView}.xml`
- `SkiaSharp.Views.iOS/{SKCanvasLayer,SKCanvasView,SKGLLayer,SKGLView}.xml`
- `SkiaSharp.Views.tvOS/{SKCanvasLayer,SKCanvasView,SKGLLayer,SKGLView}.xml`

### Group 2 — Obsolete Android `ISKRenderer` references (4 instances)
Removed the obsolete `> [!NOTE]` blocks referencing the removed nested `ISKRenderer` interface and `SetRenderer(ISKRenderer)` method. The surrounding remarks already document the modern pattern (override `OnPaintSurface` / subscribe to the `PaintSurface` event), so the docs remain coherent and accurate.
- `SkiaSharp.Views.Android/{SKGLSurfaceView,SKGLTextureView}.xml`

### Group 3 — Repoint `SKTypeface` xrefs to `SKFont` (4 instances)
The four `SKPaint` text properties were removed and now live on `SKFont`. Repointed the xrefs (targets verified to exist in `SKFont.xml`) and updated the surrounding sentence ("used in the paint" → "used in the font"):
- `SKPaint.TextSize` → `SKFont.Size`
- `SKPaint.TextSkewX` → `SKFont.SkewX`
- `SKPaint.TextScaleX` → `SKFont.ScaleX`
- `SKPaint.FakeBoldText` → `SKFont.Embolden`

## Verification
- `grep` confirms **zero** remaining references to `DrawInSurface`, `ISKRenderer`, `SetRenderer(SKGL…)`, `SKPaint.TextSize`, `SKPaint.TextSkewX`, `SKPaint.TextScaleX`, `SKPaint.FakeBoldText`. The only remaining `SetRenderer` hit is the legitimate `GLTextureView.SetRenderer(GLTextureView.IRenderer)` API member (unrelated, kept).
- All four `SKFont` xref targets exist as `<Member MemberName="Size|SkewX|ScaleX|Embolden">` in `SkiaSharp/SKFont.xml`.
- `.github/known-warnings.csv` is **not** modified — we are fixing these warnings, not allowlisting them.
- All 15 changed files validated as well-formed XML.
- Diff is surgical: only prose/xref changes (15 files, 5 insertions / 173 deletions). No signature/parameter or unrelated whitespace changes.

Unblocks Go Live PR #171.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>