### PR TITLE
Publish Learn warning status on pull requests

### DIFF
--- a/.github/workflows/automerge-docs.yml
+++ b/.github/workflows/automerge-docs.yml
@@ -4,9 +4,6 @@ on:
   status:
   check_run:
     types: [completed]
-  workflow_run:
-    workflows: [Check Learn warnings]
-    types: [completed]
 
 env:
   DRY_RUN: false
@@ -25,19 +22,17 @@ jobs:
     if: |
       (github.event_name == 'status' &&
        github.event.state == 'success' &&
-       github.event.context == 'PoliCheck Scan' &&
+       (github.event.context == 'PoliCheck Scan' ||
+        github.event.context == 'Learn warnings') &&
        contains(github.event.branches.*.name, 'automation/write-api-docs')) ||
       (github.event_name == 'check_run' &&
        github.event.check_run.conclusion == 'success' &&
        github.event.check_run.name != 'Auto-merge docs' &&
-       github.event.check_run.check_suite.head_branch == 'automation/write-api-docs') ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'automation/write-api-docs')
+       github.event.check_run.check_suite.head_branch == 'automation/write-api-docs')
 
     # Only one run at a time per PR commit.
     concurrency:
-      group: automerge-${{ github.event.workflow_run.head_sha || github.event.check_run.head_sha || github.event.sha }}
+      group: automerge-${{ github.event.check_run.head_sha || github.event.sha }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
 
@@ -50,15 +45,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           STATUS_BRANCHES_JSON: ${{ toJSON(github.event.branches.*.name) }}
           STATUS_SHA: ${{ github.event.sha }}
-          WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = "check_run" ]; then
             branch="$CHECK_BRANCH"
             event_sha="$CHECK_SHA"
-          elif [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
-            branch="$WORKFLOW_BRANCH"
-            event_sha="$WORKFLOW_SHA"
           else
             branch=$(printf '%s' "$STATUS_BRANCHES_JSON" |
               jq -r '.[] | select(. == "automation/write-api-docs")' |

--- a/.github/workflows/check-learn-warnings.yml
+++ b/.github/workflows/check-learn-warnings.yml
@@ -6,7 +6,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  statuses: read
+  statuses: write
 
 jobs:
   check-warnings:
@@ -94,6 +94,29 @@ jobs:
           else
             gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body-file "$REPORT_PATH"
           fi
+
+      - name: Publish Learn warning status
+        if: always() && steps.pr.outputs.found == 'true'
+        env:
+          CHECK_OUTCOME: ${{ steps.check.outcome }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$CHECK_OUTCOME" = "success" ]; then
+            state=success
+            description="No unrecorded Learn Build warnings"
+          else
+            state=failure
+            description="Learn Build errors or unrecorded warnings found"
+          fi
+
+          gh api --method POST "repos/$REPOSITORY/statuses/$HEAD_SHA" \
+            --raw-field state="$state" \
+            --raw-field context="Learn warnings" \
+            --raw-field description="$description" \
+            --raw-field target_url="$RUN_URL" > /dev/null
 
       - name: Fail for Learn Build findings
         if: steps.check.outcome == 'failure'


### PR DESCRIPTION
## Summary

- publishes the standalone Learn warning result as a `Learn warnings` commit status on the validated PR head
- links that status to the workflow run and reports success or failure independently of the workflow run's default-branch check
- updates the custom automerge workflow to react to successful `Learn warnings` and `PoliCheck Scan` statuses
- removes the ineffective `workflow_run` path, whose run is attached to `main` rather than the docs PR branch

## Validation

- reproduced the issue on mono/SkiaSharp-API-docs#223: the workflow failed and posted its bad-xref report, but no PR status appeared
- confirmed PoliCheck independently reported an error for the deliberate terminology test
- parsed both workflow YAML files
- reviewed the status API payload, event routing, and automerge interaction
- independent review found no status recursion or failure-propagation issues